### PR TITLE
#ME-259 disable detection of unreturned replies

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,7 @@
         "semi": ["error", "always"],
         "comma-dangle": ["error", "always-multiline"],
         "global-require" : "off",
+        "no-promise-executor-return" : "off",
         "import/prefer-default-export": "off",
         "no-shadow": "off",
         "@typescript-eslint/no-shadow": ["error"],

--- a/src/overrideFetch.ts
+++ b/src/overrideFetch.ts
@@ -42,7 +42,7 @@ export function overrideFetch() {
       clearCurrentNetmockReplyTrace();
       if (!(res instanceof NetmockResponse)) {
         if (replyTrace) {
-          throw getErrorWithCorrectStack('Error: detected unreturned reply. Did you used "reply()" instead of "return reply()"?', replyTrace);
+          // throw getErrorWithCorrectStack('Error: detected unreturned reply. Did you used "reply()" instead of "return reply()"?', replyTrace);
         }
         res = new NetmockResponse(res);
       }

--- a/tests/HandlerResponse.spec.ts
+++ b/tests/HandlerResponse.spec.ts
@@ -6,11 +6,25 @@ describe('Response', () => {
     reply = require('netmock-js').reply;
   });
 
-  it('should throw an error if someone forgot to return the reply object', async () => {
-    netmock.get('https://wix.com', () => {
-      reply('Mocked Text');
+  describe.skip('Detect unreturned replies', () => {
+    it.only('should throw an error if someone forgot to return the reply object', async () => {
+      netmock.get('https://wix.com', () => {
+        reply('Mocked Text');
+      });
+      netmock.get('https://wix2.com', async () => {
+        await new Promise((r) => setTimeout(r, 0));
+        reply('Mocked Text');
+      });
+      await expect(() => fetch('https://wix.com')).rejects.toThrow('Error: detected unreturned reply. Did you used "reply()" instead of "return reply()"?');
+      await expect(() => fetch('https://wix2.com')).rejects.toThrow('Error: detected unreturned reply. Did you used "reply()" instead of "return reply()"?');
     });
-    await expect(() => fetch('https://wix.com')).rejects.toThrow('Error: detected unreturned reply. Did you used "reply()" instead of "return reply()"?');
+
+    it('should work correctly when there are multiple requests', async () => {
+      netmock.get('https://wix.com', () => 'Mocked Text');
+      netmock.get('https://wix2.com', () => reply('Mocked Text'));
+      fetch('https://wix.com');
+      await fetch('https://wix2.com');
+    });
   });
 
   it('should support async handler', async () => {


### PR DESCRIPTION
There is a bug in the way we detect errors, and it cannot be easily fixed. I am disabling this feature now until we'll have a better solution