### PR TITLE
fix: override fetch search params entries

### DIFF
--- a/src/overrideFetch.ts
+++ b/src/overrideFetch.ts
@@ -30,7 +30,7 @@ export function overrideFetch() {
       }
       const rawRequest = new global.Request(input, init);
       const headers = Object.fromEntries(rawRequest.headers.entries());
-      const query = Object.fromEntries(new URL(url).searchParams);
+      const query = Object.fromEntries(new URL(url).searchParams.entries());
       const params = url.match(mockedEndpoint.urlRegex)?.groups ?? {};
       const body = rawRequest.body ? rawRequest.body!.toString() : undefined;
       clearCurrentNetmockReplyTrace();


### PR DESCRIPTION
Hey,

we encountered with the error:
this change fixed it when i tried locally.
```
 {
      error: TypeError: object is not iterable (cannot read property Symbol(Symbol.iterator))
          at Function.fromEntries (<anonymous>)
          at /Users/amitshw/github/wix-one-app-portal-platform/node_modules/netmock-js/lib/overrideFetch.js:41:34
          at Generator.next (<anonymous>)
          at /Users/amitshw/github/wix-one-app-portal-platform/node_modules/netmock-js/lib/overrideFetch.js:8:71
          at new Promise (<anonymous>)
          at new TrackedPromise (/Users/amitshw/github/wix-one-app-portal-platform/node_modules/@wix/amino/dist/src/jest-setup.js:140:13)
          at Object.<anonymous>.__awaiter (/Users/amitshw/github/wix-one-app-portal-platform/node_modules/netmock-js/lib/overrideFetch.js:4:12)
          at fetch (/Users/amitshw/github/wix-one-app-portal-platform/node_modules/netmock-js/lib/overrideFetch.js:22:37)
          at func (/Users/amitshw/github/wix-one-app-portal-platform/node_modules/wix-one-app-engine/src/engine/WixFetch/WixFetch.ts:153:46)
          at InFlightMap.launch (/Users/amitshw/github/wix-one-app-portal-platform/node_modules/wix-one-app-engine/src/engine/WixFetch/inFlightMap.ts:37:5) {
        metadata: {
          url: 'https://wix-life.com/_functions/v1/search',
          requestParams: [Object],
          retryIndex: 2
        }
      }
    }
```