### PR TITLE
fix settings not getting updated

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
     "rules": {
         "semi": ["error", "always"],
         "comma-dangle": ["error", "always-multiline"],
+        "no-underscore-dangle": "off",
         "global-require" : "off",
         "no-promise-executor-return" : "off",
         "import/prefer-default-export": "off",

--- a/src/NetmockResponse.ts
+++ b/src/NetmockResponse.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import type {
   NetmockResponseFields, NetmockResponseParams, Headers, NetmockResponseType,
 } from './types';

--- a/src/globalTypes.d.ts
+++ b/src/globalTypes.d.ts
@@ -1,8 +1,15 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable no-underscore-dangle */
 /* eslint-disable no-var */
 
 declare var originalFetch: typeof fetch;
-declare var netmockMockedEndpoints: {
+declare var __netmockSettings: NetmockSettings;
+declare var __netmockMockedEndpoints: {
   [method in import('./types').Method]: {
     [key: string]: import('./types').MockedEndpoint;
   }
+};
+type NetmockSettings = {
+  allowRealNetwork: boolean | RegExp;
+  suppressQueryParamsInUrlWarnings: boolean;
 };

--- a/src/globalTypes.d.ts
+++ b/src/globalTypes.d.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-/* eslint-disable no-underscore-dangle */
 /* eslint-disable no-var */
 
 declare var originalFetch: typeof fetch;

--- a/src/mockedEndpointsService.ts
+++ b/src/mockedEndpointsService.ts
@@ -12,15 +12,15 @@ function getCleanState() {
   };
 }
 
-global.netmockMockedEndpoints = getCleanState();
+global.__netmockMockedEndpoints = getCleanState();
 
 export function reset() {
-  global.netmockMockedEndpoints = getCleanState();
+  global.__netmockMockedEndpoints = getCleanState();
 }
 
 export function getMockedEndpointMetadata(method: Method, url: MockedUrl) {
   const key = getMockedEndpointKey(url);
-  return global.netmockMockedEndpoints[method][key]?.metadata;
+  return global.__netmockMockedEndpoints[method][key]?.metadata;
 }
 
 export function registerMockedEndpoint(method: Method, url: MockedUrl, handler: MockedEndpointHandler, stackTrace: string) {
@@ -38,7 +38,7 @@ export function registerMockedEndpoint(method: Method, url: MockedUrl, handler: 
   const key = getMockedEndpointKey(url);
   const urlRegex = url instanceof RegExp ? url : convertUrlToRegex(url);
   const metadata = getEmptyMetadata();
-  global.netmockMockedEndpoints[method][key] = {
+  global.__netmockMockedEndpoints[method][key] = {
     key,
     handler: getHandlerMetadataCollectorWrapper(handler, metadata),
     urlRegex,
@@ -50,9 +50,9 @@ export function registerMockedEndpoint(method: Method, url: MockedUrl, handler: 
 
 export function findMockedEndpoint(input: RequestInfo, method: Method): MockedEndpoint | undefined {
   const key = getMockedEndpointKey(input);
-  const matchDirect = global.netmockMockedEndpoints[method][key];
+  const matchDirect = global.__netmockMockedEndpoints[method][key];
   const matchByParams = () => Object
-    .values(global.netmockMockedEndpoints[method])
+    .values(global.__netmockMockedEndpoints[method])
     .find((mockedEndpoint) => mockedEndpoint.urlRegex.test(key));
 
   return matchDirect || matchByParams();

--- a/src/mockedEndpointsService.ts
+++ b/src/mockedEndpointsService.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-cycle
 import { netlogApi } from './netlog';
-import { settings } from './settings';
+import { getSettings } from './settings';
 import type {
   MockedEndpoint, MockedEndpointHandler, Method, MockedUrl, MockedEndpointMetaData,
 } from './types';
@@ -24,7 +24,7 @@ export function getMockedEndpointMetadata(method: Method, url: MockedUrl) {
 }
 
 export function registerMockedEndpoint(method: Method, url: MockedUrl, handler: MockedEndpointHandler, stackTrace: string) {
-  if (typeof url === 'string' && isContainingQueryParams(url) && !settings.suppressQueryParamsInUrlWarnings) {
+  if (typeof url === 'string' && isContainingQueryParams(url) && !getSettings().suppressQueryParamsInUrlWarnings) {
     console.warn(`
     Warning: detected query params inside a url for the following mocked endpoint: ${url}
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,10 +1,14 @@
-export const settings = {
+const settings = {
   allowRealNetwork: false as boolean | RegExp,
   suppressQueryParamsInUrlWarnings: false as boolean,
 };
 
 export function configure(value: Partial<typeof settings>) {
   Object.assign(settings, value);
+}
+
+export function getSettings() {
+  return { ...settings };
 }
 
 export function isRealNetworkAllowed(url: string) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-underscore-dangle */
-
 global.__netmockSettings = {
   allowRealNetwork: false,
   suppressQueryParamsInUrlWarnings: false,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,19 +1,21 @@
-const settings = {
-  allowRealNetwork: false as boolean | RegExp,
-  suppressQueryParamsInUrlWarnings: false as boolean,
+/* eslint-disable no-underscore-dangle */
+
+global.__netmockSettings = {
+  allowRealNetwork: false,
+  suppressQueryParamsInUrlWarnings: false,
 };
 
-export function configure(value: Partial<typeof settings>) {
-  Object.assign(settings, value);
+export function configure(value: Partial<typeof global.__netmockSettings>) {
+  Object.assign(global.__netmockSettings, value);
 }
 
 export function getSettings() {
-  return { ...settings };
+  return global.__netmockSettings;
 }
 
 export function isRealNetworkAllowed(url: string) {
-  if (typeof settings.allowRealNetwork === 'boolean') {
-    return settings.allowRealNetwork;
+  if (typeof global.__netmockSettings.allowRealNetwork === 'boolean') {
+    return global.__netmockSettings.allowRealNetwork;
   }
-  return settings.allowRealNetwork.test(url);
+  return global.__netmockSettings.allowRealNetwork.test(url);
 }

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -8,7 +8,7 @@ describe('Settings', () => {
   it('setting one configuration should not override the other', () => {
     configure({ allowRealNetwork: true });
     configure({ suppressQueryParamsInUrlWarnings: true });
-    expect(require('../src/settings').settings).toEqual({
+    expect(require('../src/settings').getSettings()).toEqual({
       allowRealNetwork: true,
       suppressQueryParamsInUrlWarnings: true,
     });


### PR DESCRIPTION
in the old implementation, the js output looked like this:
```javascript
exports.settings = {
    allowRealNetwork: false,
    suppressQueryParamsInUrlWarnings: false,
};
```

I am not sure, but I think that it cases the settings object to be cloned on import, and then the mockedServiceEndpoint worked against an old copy of the settings. this pr makes sure that the settings are always fresh